### PR TITLE
Emit a end event when the request queue is empty.

### DIFF
--- a/tests/test_nytimes.js
+++ b/tests/test_nytimes.js
@@ -27,4 +27,7 @@ spider()
 })
 .get('http://www.nytimes.com/pages/dining/index.html')
 .log('info')
+.on('end', function() {
+  console.log('end');
+})
 ;


### PR DESCRIPTION
Hi,

I have added an emit event.

This event can not reflect the reality if the callback is asynchronous and a
new request is triggered.

What do you think about that ?
