### PR TITLE
Get maxSockets from this on Spider constructor to prevent getting undefined from options

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ function Spider (options) {
   this.maxSockets = options.maxSockets || 4;
   this.userAgent = options.userAgent || firefox;
   this.cache = options.cache || new NoCache();
-  this.pool = options.pool || {maxSockets: options.maxSockets};
+  this.pool = options.pool || {maxSockets: this.maxSockets};
   this.options = options;
   this.currentUrl = null;
   this.routers = {};


### PR DESCRIPTION
Currently, if you don't provide maxSockets and pool through options parameter, you will get a pool like this: 
```javascript
{maxSockets: undefined}
```